### PR TITLE
syntax cleanup

### DIFF
--- a/src/DatabaseHandle.php
+++ b/src/DatabaseHandle.php
@@ -1,67 +1,76 @@
 <?php
 declare(strict_types=1);
+
 namespace iggyvolz\lmdb;
+
 use FFI;
+
 class DatabaseHandle
 {
+    private int $handle;
+
     private static function newString(string $val): FFI\Cdata
     {
-        $cdata = FFI::new("const char[".(strlen($val)+1)."]", false);
+        $cdata = FFI::new('const char['.(strlen($val)+1).']', false);
         FFI::memcpy($cdata, $val, strlen($val));
         return $cdata;
     }
-    private int $handle;
+
     public function __construct(private Transaction $transaction, ?string $name = null, int $flags = 0)
     {
-        $handle = LMDB::new("MDB_dbi");
-        if(!is_null($name)) {
-            $namePtr = FFI::new("const char[".(strlen($name)+1)."]");
+        $handle = LMDB::new('MDB_dbi');
+        if (!is_null($name)) {
+            $namePtr = FFI::new('const char['.(strlen($name)+1).']');
             FFI::memcpy($namePtr, $name, strlen($name));
         } else {
-            $namePtr = LMDB::cast("const char*", 0);
+            $namePtr = LMDB::cast('const char*', 0);
         }
         LMDB::assert(LMDB::mdb_dbi_open($transaction->cdata, $namePtr, $flags, FFI::addr($handle)));
         $this->handle = $handle->cdata;
     }
+
     public function put(string $key, string $value, int $flags = 0): void
     {
-        $keyVal = LMDB::new("MDB_val");
+        $keyVal = LMDB::new('MDB_val');
         $keyVal->mv_size=strlen($key);
         $keyVal->mv_data=self::newString($key);
-        $dataVal = LMDB::new("MDB_val");
+        $dataVal = LMDB::new('MDB_val');
         $dataVal->mv_size=strlen($value);
         $dataVal->mv_data=self::newString($value);
         LMDB::assert(LMDB::mdb_put($this->transaction->cdata, $this->handle, FFI::addr($keyVal), FFI::addr($dataVal), $flags));
     }
+
     public function get(string $key): ?string
     {
-        $keyVal = LMDB::new("MDB_val");
+        $keyVal = LMDB::new('MDB_val');
         $keyVal->mv_size=strlen($key);
         $keyVal->mv_data=self::newString($key);
-        $dataVal = LMDB::new("MDB_val");
+        $dataVal = LMDB::new('MDB_val');
         $res = LMDB::mdb_get($this->transaction->cdata, $this->handle, FFI::addr($keyVal), FFI::addr($dataVal));
-        if($res === LMDB::NOTFOUND) {
+        if ($res === LMDB::NOTFOUND) {
             return null;
         }
         LMDB::assert($res);
         return FFI::string($dataVal->mv_data, $dataVal->mv_size);
     }
+
     public function all(): \Generator
     {
-        $cursor = LMDB::new("MDB_cursor*");
+        $cursor = LMDB::new('MDB_cursor*');
         LMDB::assert(LMDB::mdb_cursor_open($this->transaction->cdata, $this->handle, FFI::addr($cursor)));
         // Handle MDB_NOTFOUND as exit condition
-        $key = LMDB::new("MDB_val");
-        $data = LMDB::new("MDB_val");
+        $key = LMDB::new('MDB_val');
+        $data = LMDB::new('MDB_val');
         $ret = LMDB::mdb_cursor_get($cursor, FFI::addr($key), FFI::addr($data), LMDB::FIRST);
-        while($ret === 0) {
+        while ($ret === 0) {
             yield FFI::string($key->mv_data, $key->mv_size) => FFI::string($data->mv_data, $data->mv_size);
             $ret = LMDB::mdb_cursor_get($cursor, FFI::addr($key), FFI::addr($data), LMDB::NEXT);
         }
-        if($ret !== LMDB::NOTFOUND) {
+        if ($ret !== LMDB::NOTFOUND) {
             LMDB::assert($ret);
         }
     }
+
     public function __destruct()
     {
         LMDB::mdb_dbi_close(LMDB::mdb_txn_env($this->transaction->cdata), $this->handle);

--- a/src/Environment.php
+++ b/src/Environment.php
@@ -1,24 +1,30 @@
 <?php
 declare(strict_types=1);
+
 namespace iggyvolz\lmdb;
+
 use FFI;
+
 class Environment
 {
     public FFI\CData $cdata;
+
     public function __construct(string $path, int $flags = 0, int $mode = 0755, int $numDatabases = 0)
     {
-        $this->cdata = LMDB::new("MDB_env*");
+        $this->cdata = LMDB::new('MDB_env*');
         LMDB::assert(LMDB::mdb_env_create(FFI::addr($this->cdata)));
         if($numDatabases !== 0) {
             LMDB::assert(LMDB::mdb_env_set_maxdbs($this->cdata, $numDatabases));
         }
         LMDB::assert(LMDB::mdb_env_open($this->cdata, $path, $flags, $mode));
     }
+
     public function newTransaction(bool $readOnly = false): Transaction
     {
-        $parent = FFI::cast("void*", null);
+        $parent = FFI::cast('void*', null);
         return new Transaction($this, $parent, $readOnly ? 0x20000 : 0);
     }
+
     public function __destruct()
     {
         LMDB::mdb_env_close($this->cdata);

--- a/src/LMDB.php
+++ b/src/LMDB.php
@@ -1,7 +1,10 @@
 <?php
 declare(strict_types=1);
+
 namespace iggyvolz\lmdb;
+
 use FFI;
+
 class LMDB
 {
     public const FIXEDMAP = 0x01;
@@ -52,7 +55,7 @@ class LMDB
     public const BAD_TXN = -30782;
     public const BAD_VALSIZE = -30781;
     public const BAD_DBI = -30780;
-    
+
     public const FIRST = 0;
     public const FIRST_DUP = 1;
     public const GET_BOTH = 2;
@@ -73,6 +76,7 @@ class LMDB
     public const SET_RANGE = 17;
     public const PREV_MULTIPLE = 18;
     private FFI $ffi;
+
     private function __construct()
     {
         $this->ffi = FFI::cdef(<<<'EOT'
@@ -187,26 +191,29 @@ class LMDB
         int mdb_reader_check(MDB_env *env, int *dead);
         EOT, "liblmdb.so");
     }
+
     public static function __callStatic(string $name, array $arguments): mixed
     {
         return self::get()->ffi->$name(...$arguments);
     }
+
     private static ?LMDB $instance = null;
+
     private static function get(): self
     {
         return self::$instance ??= new self();
     }
+
     public static function getVersion(): string
     {
-        $major = self::new("int");
-        $minor = self::new("int");
-        $patch = self::new("int");
-        self::mdb_version(FFI::addr($major),FFI::addr($minor),FFI::addr($patch));
-        return "$major.$minor.$patch";
+        [$major, $minor, $patch] = [self::new('int'), self::new('int'), self::new('int')];
+        self::mdb_version(FFI::addr($major), FFI::addr($minor), FFI::addr($patch));
+        return "{$major}.{$minor}.{$patch}";
     }
+
     public static function assert(int $result): void
     {
-        if($result !== 0) {
+        if ($result !== 0) {
             throw new LMDBException($result);
         }
     }

--- a/src/LMDBException.php
+++ b/src/LMDBException.php
@@ -1,8 +1,11 @@
 <?php
 declare(strict_types=1);
+
 namespace iggyvolz\lmdb;
+
 use Exception;
 use FFI;
+
 class LMDBException extends Exception
 {
     public function __construct(int $error)

--- a/src/Transaction.php
+++ b/src/Transaction.php
@@ -1,42 +1,51 @@
 <?php
 declare(strict_types=1);
+
 namespace iggyvolz\lmdb;
+
 use FFI;
+
 class Transaction
 {
     private bool $live = true;
     public FFI\CData $cdata;
+
     public function __construct(private Environment $environment, FFI\CData $parent, int $flags)
     {
-        $this->cdata = LMDB::new("MDB_txn*");
+        $this->cdata = LMDB::new('MDB_txn*');
         LMDB::assert(LMDB::mdb_txn_begin($environment->cdata, $parent, $flags, FFI::addr($this->cdata)));
     }
+
     private function assertLive(): void
     {
-        if(!$this->live) {
+        if (!$this->live) {
             throw new \RuntimeException("Illegal access on dead transaction");
         }
     }
+
     public function getHandle(?string $name = null, int $flags = 0): DatabaseHandle
     {
         $this->assertLive();
         return new DatabaseHandle($this, $name, $flags);
     }
+
     public function abort(): void
     {
         $this->assertLive();
         LMDB::mdb_txn_abort($this->cdata);
         $this->live = false;
     }
+
     public function commit(): void
     {
         $this->assertLive();
         LMDB::mdb_txn_commit($this->cdata);
         $this->live = false;
     }
+
     public function __destruct()
     {
-        if($this->live) {
+        if ($this->live) {
             $this->abort();
         }
     }


### PR DESCRIPTION

Minor syntax cleanup.

- replace double-quotes with single quotes on strings so that the interpreter doesn't check for parseable variables
- add whitespace for readability and closer PSR-12 compliance
